### PR TITLE
Fix base path configuration to prevent 404

### DIFF
--- a/bafa-buddy-main/src/App.tsx
+++ b/bafa-buddy-main/src/App.tsx
@@ -15,7 +15,7 @@ const App = () => (
       <LanguageProvider>
         <Toaster />
         <Sonner />
-        <BrowserRouter>
+        <BrowserRouter basename={import.meta.env.BASE_URL}>
           <Routes>
             <Route path="/" element={<Index />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/bafa-buddy-main/vite.config.ts
+++ b/bafa-buddy-main/vite.config.ts
@@ -5,6 +5,7 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
+  base: "./",
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- ensure BrowserRouter uses the build base URL
- configure Vite to emit relative asset paths for subdirectory hosting

## Testing
- `npm run build`
- `npm run lint` *(fails: React hook used conditionally and other pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68af1a42ec9c832194ca5f7431015929