### PR TITLE
Invert button colors on hover

### DIFF
--- a/bafa-buddy-main/src/components/ui/button.tsx
+++ b/bafa-buddy-main/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:invert",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary
- invert button and text colors on hover via CSS filter

## Testing
- `npm test` (missing script: test)
- `npm run lint` (fails: React Hooks must be called unconditionally, etc.)

------
https://chatgpt.com/codex/tasks/task_e_68af5dbfa158832182b984dab31f96b2