### PR TITLE
feat: add automatic dark mode and box glow effects

### DIFF
--- a/bafa-buddy-main/index.html
+++ b/bafa-buddy-main/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
     <title>Arrotec - Smart Energy Audit Platform | BAFA-Ready Solutions</title>
     <meta name="description" content="Professional energy audit and management platform. BAFA-compliant applications, automated reporting, auditor marketplace. Minimal, precise, efficient." />
     <meta name="author" content="Lovable" />

--- a/bafa-buddy-main/src/components/InteractiveFeatures.tsx
+++ b/bafa-buddy-main/src/components/InteractiveFeatures.tsx
@@ -12,14 +12,15 @@ interface FeatureCardProps {
   index: number;
 }
 
-const FeatureCard: React.FC<FeatureCardProps> = ({ 
-  icon: Icon, 
-  title, 
-  description, 
-  expandedContent, 
-  index 
-}) => {
-  const [isExpanded, setIsExpanded] = useState(false);
+  const FeatureCard: React.FC<FeatureCardProps> = ({
+    icon: Icon,
+    title,
+    description,
+    expandedContent,
+    index
+  }) => {
+    const [isExpanded, setIsExpanded] = useState(false);
+    const { t } = useLanguage();
 
   return (
     <Card 
@@ -49,16 +50,16 @@ const FeatureCard: React.FC<FeatureCardProps> = ({
           onClick={() => setIsExpanded(!isExpanded)}
           className="mt-4 p-0 h-auto font-medium text-foreground hover:text-foreground/80 transition-colors"
         >
-          {isExpanded ? (
-            <>
-              {useLanguage().t('common.showLess')} <ChevronUp className="ml-1 h-4 w-4" />
-            </>
-          ) : (
-            <>
-              {useLanguage().t('common.readMore')} <ChevronDown className="ml-1 h-4 w-4" />
-            </>
-          )}
-        </Button>
+            {isExpanded ? (
+              <>
+                {t('common.showLess')} <ChevronUp className="ml-1 h-4 w-4" />
+              </>
+            ) : (
+              <>
+                {t('common.readMore')} <ChevronDown className="ml-1 h-4 w-4" />
+              </>
+            )}
+          </Button>
       </CardContent>
     </Card>
   );

--- a/bafa-buddy-main/src/components/ui/alert.tsx
+++ b/bafa-buddy-main/src/components/ui/alert.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const alertVariants = cva(
-  "relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground",
+  "relative w-full rounded-lg border p-4 shadow-sm dark:shadow-white-glow [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground",
   {
     variants: {
       variant: {

--- a/bafa-buddy-main/src/components/ui/card.tsx
+++ b/bafa-buddy-main/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      "rounded-lg border bg-card text-card-foreground shadow-sm dark:shadow-white-glow",
       className
     )}
     {...props}

--- a/bafa-buddy-main/src/components/ui/command.tsx
+++ b/bafa-buddy-main/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/bafa-buddy-main/src/components/ui/textarea.tsx
+++ b/bafa-buddy-main/src/components/ui/textarea.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps =
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/bafa-buddy-main/src/index.css
+++ b/bafa-buddy-main/src/index.css
@@ -273,3 +273,9 @@
     }
   }
 }
+
+@layer utilities {
+  .shadow-white-glow {
+    box-shadow: 0 0 10px 0 rgba(255, 255, 255, 0.15);
+  }
+}

--- a/bafa-buddy-main/src/main.tsx
+++ b/bafa-buddy-main/src/main.tsx
@@ -2,4 +2,12 @@ import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
 
-createRoot(document.getElementById("root")!).render(<App />);
+const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+const setTheme = (isDark: boolean) => {
+  document.documentElement.classList.toggle('dark', isDark)
+}
+
+setTheme(mediaQuery.matches)
+mediaQuery.addEventListener('change', (e) => setTheme(e.matches))
+
+createRoot(document.getElementById('root')!).render(<App />)

--- a/bafa-buddy-main/tailwind.config.ts
+++ b/bafa-buddy-main/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -96,5 +97,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- auto-apply dark mode based on system preference
- invert theme colors and add white glow utility
- highlight card-like components with white glow

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af6382c4d8832188dcc9b7c0eb681a