### PR TITLE
Expand hero banner to full viewport

### DIFF
--- a/bafa-buddy-main/src/index.css
+++ b/bafa-buddy-main/src/index.css
@@ -152,7 +152,11 @@
 
   /* Text Animations */
   .animate-text-glow {
-    animation: text-glow 2s ease-in-out infinite alternate;
+    animation: text-glow-light 2s ease-in-out infinite alternate;
+  }
+
+  .dark .animate-text-glow {
+    animation-name: text-glow-dark;
   }
 
   .animate-fade-in-up {
@@ -221,7 +225,12 @@
   .stagger-3 { animation-delay: 0.3s; }
   .stagger-4 { animation-delay: 0.4s; }
 
-  @keyframes text-glow {
+  @keyframes text-glow-light {
+    0% { text-shadow: 0 0 3px hsl(var(--foreground) / 0.2); }
+    100% { text-shadow: 0 0 8px hsl(var(--foreground) / 0.3), 0 0 16px hsl(var(--foreground) / 0.2); }
+  }
+
+  @keyframes text-glow-dark {
     0% { text-shadow: 0 0 5px hsl(var(--foreground) / 0.3); }
     100% { text-shadow: 0 0 15px hsl(var(--foreground) / 0.6), 0 0 25px hsl(var(--foreground) / 0.4); }
   }

--- a/bafa-buddy-main/src/pages/Index.tsx
+++ b/bafa-buddy-main/src/pages/Index.tsx
@@ -39,7 +39,7 @@ const Index = () => {
       <Navigation />
       
       {/* Hero Section */}
-      <section className="relative pt-20 pb-32 overflow-hidden">
+      <section className="relative mt-16 h-[calc(100vh-4rem)] flex items-center overflow-hidden">
         <div className="absolute inset-0 grid-pattern-subtle opacity-40"></div>
 
         {/* Animated circles covering two-thirds of banner on desktop */}
@@ -52,7 +52,7 @@ const Index = () => {
           </div>
         </div>
 
-        <div className="relative max-w-7xl mx-auto px-6 lg:px-8">
+        <div className="relative max-w-7xl mx-auto px-6 lg:px-8 mt-8">
           <div className="text-center mx-auto max-w-2xl space-y-8">
             <div className="space-y-6">
               <Badge


### PR DESCRIPTION
## Summary
- Stretch hero section to full viewport height and center content with spacing
- Soften word glow in light mode while preserving stronger dark mode animation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af692a6410832180f0e3199248fb7d