### PR TITLE
Fix dark mode hero title and circle colors

### DIFF
--- a/bafa-buddy-main/src/index.css
+++ b/bafa-buddy-main/src/index.css
@@ -78,6 +78,10 @@
     --muted: 0 0% 8%;
     --muted-foreground: 0 0% 55%;
 
+    /* Bright accent colors for dark mode */
+    --accent-blue: 210 100% 70%;
+    --accent-green: 142 76% 45%;
+
     --border: 0 0% 12%;
     --input: 0 0% 12%;
     --ring: 0 0% 90%;
@@ -110,13 +114,6 @@
       linear-gradient(hsl(var(--grid-color) / 0.3) 1px, transparent 1px),
       linear-gradient(90deg, hsl(var(--grid-color) / 0.3) 1px, transparent 1px);
     background-size: calc(var(--grid-size) * 2) calc(var(--grid-size) * 2);
-  }
-
-  .gradient-text {
-    background: linear-gradient(135deg, hsl(var(--accent-blue)), hsl(var(--accent-green)));
-    -webkit-background-clip: text;
-    background-clip: text;
-    -webkit-text-fill-color: transparent;
   }
 
   /* Circle Outlines Signature Element */

--- a/bafa-buddy-main/src/pages/Index.tsx
+++ b/bafa-buddy-main/src/pages/Index.tsx
@@ -45,10 +45,10 @@ const Index = () => {
         {/* Animated circles covering two-thirds of banner on desktop */}
         <div className="pointer-events-none absolute inset-y-0 right-0 w-full lg:w-2/3">
           <div className="relative w-full h-full">
-            <div className="absolute top-10 left-[5%] w-96 h-96 border-2 border-foreground/20 rounded-full animate-wave-1"></div>
-            <div className="absolute top-20 left-[30%] w-[28rem] h-[28rem] border-2 border-foreground/20 rounded-full animate-wave-2"></div>
-            <div className="absolute top-6 left-[55%] w-[32rem] h-[32rem] border-2 border-foreground/20 rounded-full animate-wave-3"></div>
-            <div className="absolute top-24 left-[75%] w-80 h-80 border-2 border-foreground/20 rounded-full animate-wave-4"></div>
+            <div className="absolute top-10 left-[5%] w-96 h-96 border-2 border-blue-400/30 rounded-full animate-wave-1"></div>
+            <div className="absolute top-20 left-[30%] w-[28rem] h-[28rem] border-2 border-purple-400/30 rounded-full animate-wave-2"></div>
+            <div className="absolute top-6 left-[55%] w-[32rem] h-[32rem] border-2 border-green-400/30 rounded-full animate-wave-3"></div>
+            <div className="absolute top-24 left-[75%] w-80 h-80 border-2 border-pink-400/30 rounded-full animate-wave-4"></div>
           </div>
         </div>
 

--- a/bafa-buddy-main/src/pages/Index.tsx
+++ b/bafa-buddy-main/src/pages/Index.tsx
@@ -63,9 +63,9 @@ const Index = () => {
               </Badge>
               <h1 className="text-5xl lg:text-7xl font-bold leading-[0.9] tracking-tight">
                 <span className="animate-hero-text">{t('hero.title.the')}</span>{" "}
-                <span className="animate-hero-text-delayed animate-text-glow text-black dark:text-white">{t('hero.title.smart')}</span>{" "}
+                <span className="animate-hero-text-delayed animate-text-glow text-foreground">{t('hero.title.smart')}</span>{" "}
                 <span className="animate-hero-text-delayed-2">{t('hero.title.for')}</span>{" "}
-                <span className="animate-hero-text-delayed-3 animate-text-glow text-black dark:text-white">
+                <span className="animate-hero-text-delayed-3 animate-text-glow text-foreground">
                   {t('hero.title.audits')}
                 </span>
               </h1>

--- a/bafa-buddy-main/src/pages/Index.tsx
+++ b/bafa-buddy-main/src/pages/Index.tsx
@@ -45,10 +45,10 @@ const Index = () => {
         {/* Animated circles covering two-thirds of banner on desktop */}
         <div className="pointer-events-none absolute inset-y-0 right-0 w-full lg:w-2/3">
           <div className="relative w-full h-full">
-            <div className="absolute top-10 left-[5%] w-72 h-72 border-2 border-foreground/12 rounded-full animate-wave-1"></div>
-            <div className="absolute top-20 left-[30%] w-80 h-80 border-2 border-foreground/16 rounded-full animate-wave-2"></div>
-            <div className="absolute top-6 left-[55%] w-96 h-96 border-2 border-foreground/14 rounded-full animate-wave-3"></div>
-            <div className="absolute top-24 left-[75%] w-64 h-64 border-2 border-foreground/20 rounded-full animate-wave-4"></div>
+            <div className="absolute top-10 left-[5%] w-96 h-96 border-2 border-foreground/20 rounded-full animate-wave-1"></div>
+            <div className="absolute top-20 left-[30%] w-[28rem] h-[28rem] border-2 border-foreground/20 rounded-full animate-wave-2"></div>
+            <div className="absolute top-6 left-[55%] w-[32rem] h-[32rem] border-2 border-foreground/20 rounded-full animate-wave-3"></div>
+            <div className="absolute top-24 left-[75%] w-80 h-80 border-2 border-foreground/20 rounded-full animate-wave-4"></div>
           </div>
         </div>
 
@@ -63,9 +63,9 @@ const Index = () => {
               </Badge>
               <h1 className="text-5xl lg:text-7xl font-bold leading-[0.9] tracking-tight">
                 <span className="animate-hero-text">{t('hero.title.the')}</span>{" "}
-                <span className="animate-hero-text-delayed animate-text-glow">{t('hero.title.smart')}</span>{" "}
+                <span className="animate-hero-text-delayed animate-text-glow text-black dark:text-white">{t('hero.title.smart')}</span>{" "}
                 <span className="animate-hero-text-delayed-2">{t('hero.title.for')}</span>{" "}
-                <span className="gradient-text animate-hero-text-delayed-3 animate-text-glow">
+                <span className="animate-hero-text-delayed-3 animate-text-glow text-black dark:text-white">
                   {t('hero.title.audits')}
                 </span>
               </h1>


### PR DESCRIPTION
## Summary
- Ensure hero banner shows "smart platform" and "energy audits" in dark mode
- Restore animated hero circles to monochrome so they appear black in light mode and white in dark mode

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af6b2c545483219bdfbdf3f8fa0902