### PR TITLE
Revert latest UI tweaks

### DIFF
--- a/bafa-buddy-main/src/index.css
+++ b/bafa-buddy-main/src/index.css
@@ -116,6 +116,13 @@
     background-size: calc(var(--grid-size) * 2) calc(var(--grid-size) * 2);
   }
 
+  .gradient-text {
+    background: linear-gradient(135deg, hsl(var(--accent-blue)), hsl(var(--accent-green)));
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+
   /* Circle Outlines Signature Element */
   .circle-outline {
     position: relative;

--- a/bafa-buddy-main/src/pages/Index.tsx
+++ b/bafa-buddy-main/src/pages/Index.tsx
@@ -63,9 +63,9 @@ const Index = () => {
               </Badge>
               <h1 className="text-5xl lg:text-7xl font-bold leading-[0.9] tracking-tight">
                 <span className="animate-hero-text">{t('hero.title.the')}</span>{" "}
-                <span className="animate-hero-text-delayed animate-text-glow text-foreground">{t('hero.title.smart')}</span>{" "}
+                <span className="animate-hero-text-delayed animate-text-glow text-black dark:text-white">{t('hero.title.smart')}</span>{" "}
                 <span className="animate-hero-text-delayed-2">{t('hero.title.for')}</span>{" "}
-                <span className="animate-hero-text-delayed-3 animate-text-glow text-foreground">
+                <span className="gradient-text animate-hero-text-delayed-3 animate-text-glow">
                   {t('hero.title.audits')}
                 </span>
               </h1>


### PR DESCRIPTION
## Summary
- Revert merge of hero banner tweaks and dark-mode text adjustments
- Undo theme-based hero title colors, restoring previous styles

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af783be28c8321bd710cbb6263414d