### PR TITLE
Unify compliance icons and rename GDPR label

### DIFF
--- a/bafa-buddy-main/src/contexts/LanguageContext.tsx
+++ b/bafa-buddy-main/src/contexts/LanguageContext.tsx
@@ -30,7 +30,7 @@ const translations = {
     'hero.cta.learn': 'Learn More',
     'hero.compliance.bafa': 'BAFA-compliant',
     'hero.compliance.iso': 'ISO 50001',
-    'hero.compliance.gdpr': 'GDPR-ready',
+    'hero.compliance.gdpr': 'DSVGO',
     
     // Features Section
     'features.title': 'Built for',

--- a/bafa-buddy-main/src/pages/Index.tsx
+++ b/bafa-buddy-main/src/pages/Index.tsx
@@ -25,10 +25,7 @@ import {
   Lightbulb,
   Target,
   Workflow,
-  Database,
-  Sparkles,
-  Lock,
-  Atom
+  Database
 } from "lucide-react";
 import { useLanguage } from "@/contexts/LanguageContext";
 
@@ -86,15 +83,15 @@ const Index = () => {
 
             <div className="flex items-center justify-center gap-8 pt-6 animate-fade-in-up stagger-4">
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                <Sparkles className="h-4 w-4 text-foreground" />
+                <Shield className="h-4 w-4 text-foreground" />
                 <span>{t('hero.compliance.bafa')}</span>
               </div>
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                <Atom className="h-4 w-4 text-foreground" />
+                <Shield className="h-4 w-4 text-foreground" />
                 <span>{t('hero.compliance.iso')}</span>
               </div>
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                <Lock className="h-4 w-4 text-foreground" />
+                <Shield className="h-4 w-4 text-foreground" />
                 <span>{t('hero.compliance.gdpr')}</span>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- use a single shield icon for BAFA-compliant, ISO 50001 and DSVGO indicators
- rename GDPR-ready label to DSVGO

## Testing
- `npm test` (missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af8165a8d88321b77b3965f162d5ec