### PR TITLE
Fix navigation brand name and dark mode hero text

### DIFF
--- a/bafa-buddy-main/src/components/Navigation.tsx
+++ b/bafa-buddy-main/src/components/Navigation.tsx
@@ -15,7 +15,7 @@ const Navigation = () => {
           {/* Brand Name */}
           <div className="flex items-center">
             <span className="text-xl font-semibold tracking-tight">
-              Arrotec
+              Arotec
             </span>
           </div>
 

--- a/bafa-buddy-main/src/index.css
+++ b/bafa-buddy-main/src/index.css
@@ -120,7 +120,7 @@
     background: linear-gradient(135deg, hsl(var(--accent-blue)), hsl(var(--accent-green)));
     -webkit-background-clip: text;
     background-clip: text;
-    -webkit-text-fill-color: transparent;
+    color: transparent;
   }
 
   /* Circle Outlines Signature Element */

--- a/bafa-buddy-main/src/pages/Index.tsx
+++ b/bafa-buddy-main/src/pages/Index.tsx
@@ -60,9 +60,9 @@ const Index = () => {
               </Badge>
               <h1 className="text-5xl lg:text-7xl font-bold leading-[0.9] tracking-tight">
                 <span className="animate-hero-text">{t('hero.title.the')}</span>{" "}
-                <span className="animate-hero-text-delayed animate-text-glow text-black dark:text-white">{t('hero.title.smart')}</span>{" "}
+                <span className="animate-hero-text-delayed animate-text-glow text-foreground">{t('hero.title.smart')}</span>{" "}
                 <span className="animate-hero-text-delayed-2">{t('hero.title.for')}</span>{" "}
-                <span className="gradient-text animate-hero-text-delayed-3 animate-text-glow">
+                <span className="gradient-text dark:text-white animate-hero-text-delayed-3 animate-text-glow">
                   {t('hero.title.audits')}
                 </span>
               </h1>


### PR DESCRIPTION
## Summary
- Rename top-left menu brand from Arrotec to Arotec
- Ensure "smart platform" and "energy audits" hero text remains visible in dark mode

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af8383a2108321bb3fed39a62676ea