### PR TITLE
Replace hero banner outlines with dotted circle graphics

### DIFF
--- a/bafa-buddy-main/src/assets/dotted-circle.svg
+++ b/bafa-buddy-main/src/assets/dotted-circle.svg
@@ -1,0 +1,11 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g stroke="rgba(15, 23, 42, 0.18)" stroke-width="14" stroke-linecap="round" fill="none">
+    <circle cx="256" cy="256" r="224" stroke-dasharray="0 34" />
+    <circle cx="256" cy="256" r="186" stroke-dasharray="0 30" />
+    <circle cx="256" cy="256" r="150" stroke-dasharray="0 26" />
+    <circle cx="256" cy="256" r="116" stroke-dasharray="0 22" />
+    <circle cx="256" cy="256" r="86" stroke-dasharray="0 18" />
+    <circle cx="256" cy="256" r="60" stroke-dasharray="0 14" />
+    <circle cx="256" cy="256" r="38" stroke-dasharray="0 10" />
+  </g>
+</svg>

--- a/bafa-buddy-main/src/pages/Index.tsx
+++ b/bafa-buddy-main/src/pages/Index.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import dottedCircle from "@/assets/dotted-circle.svg";
 import { 
   ArrowRight,
   FileText, 
@@ -42,10 +43,42 @@ const Index = () => {
         {/* Animated circles covering two-thirds of banner on desktop */}
         <div className="pointer-events-none absolute inset-y-0 right-0 w-full lg:w-2/3">
           <div className="relative w-full h-full">
-            <div className="absolute top-10 left-[5%] w-96 h-96 border-2 border-foreground/20 rounded-full animate-wave-1"></div>
-            <div className="absolute top-20 left-[30%] w-[28rem] h-[28rem] border-2 border-foreground/20 rounded-full animate-wave-2"></div>
-            <div className="absolute top-6 left-[55%] w-[32rem] h-[32rem] border-2 border-foreground/20 rounded-full animate-wave-3"></div>
-            <div className="absolute top-24 left-[75%] w-80 h-80 border-2 border-foreground/20 rounded-full animate-wave-4"></div>
+            <div
+              className="absolute top-10 left-[5%] w-96 h-96 rounded-full overflow-hidden animate-wave-1 bg-background"
+              style={{
+                backgroundImage: `url(${dottedCircle})`,
+                backgroundSize: "cover",
+                backgroundPosition: "center",
+                backgroundRepeat: "no-repeat"
+              }}
+            ></div>
+            <div
+              className="absolute top-20 left-[30%] w-[28rem] h-[28rem] rounded-full overflow-hidden animate-wave-2 bg-background"
+              style={{
+                backgroundImage: `url(${dottedCircle})`,
+                backgroundSize: "cover",
+                backgroundPosition: "center",
+                backgroundRepeat: "no-repeat"
+              }}
+            ></div>
+            <div
+              className="absolute top-6 left-[55%] w-[32rem] h-[32rem] rounded-full overflow-hidden animate-wave-3 bg-background"
+              style={{
+                backgroundImage: `url(${dottedCircle})`,
+                backgroundSize: "cover",
+                backgroundPosition: "center",
+                backgroundRepeat: "no-repeat"
+              }}
+            ></div>
+            <div
+              className="absolute top-24 left-[75%] w-80 h-80 rounded-full overflow-hidden animate-wave-4 bg-background"
+              style={{
+                backgroundImage: `url(${dottedCircle})`,
+                backgroundSize: "cover",
+                backgroundPosition: "center",
+                backgroundRepeat: "no-repeat"
+              }}
+            ></div>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- replace the hero banner outline circles with a dotted circle background while keeping the original animations
- add a reusable dotted circle SVG asset to supply the new background artwork

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd62b2fcb48321a77d7066cd3e3107