### PR TITLE
Adjust hero title spacing and smooth ring animation

### DIFF
--- a/bafa-buddy-main/src/index.css
+++ b/bafa-buddy-main/src/index.css
@@ -214,6 +214,14 @@
     transform: translateY(30px) scale(0.9);
   }
 
+  .hero-rings-wrapper {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    animation: hero-rings-flow var(--hero-entry-duration, 2s)
+      cubic-bezier(0.19, 1, 0.22, 1) both;
+  }
+
   .hero-ring {
     position: absolute;
     border-radius: 9999px;
@@ -222,16 +230,10 @@
     --ring-glow-color: var(--ring-glow-color-light, rgba(79, 70, 229, 0.35));
     --ring-dot-size: var(--ring-dot-size, 12px);
     --ring-radius: var(--ring-radius, 150px);
-    --hero-entry-duration: 1.6s;
-    --hero-entry-delay: 0s;
+    --hero-entry-duration: 2s;
     --hero-wave-delay-offset: 0s;
-    animation-name: hero-ring-entry, wave-motion;
-    animation-duration: var(--hero-entry-duration), 6s;
-    animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1), ease-in-out;
-    animation-delay: var(--hero-entry-delay),
-      calc(var(--hero-entry-delay) + var(--hero-entry-duration) + var(--hero-wave-delay-offset));
-    animation-iteration-count: 1, infinite;
-    animation-fill-mode: both, none;
+    animation: wave-motion 6s ease-in-out
+      calc(var(--hero-entry-duration) + var(--hero-wave-delay-offset)) infinite;
   }
 
   .hero-dot {
@@ -241,8 +243,8 @@
     transform: translate(-50%, -50%) rotate(var(--dot-angle))
       translateX(var(--ring-radius));
     opacity: 0;
-    animation: hero-dot-assemble var(--hero-entry-duration)
-      cubic-bezier(0.22, 1, 0.36, 1) var(--hero-entry-delay) both;
+    animation: hero-dot-assemble var(--hero-entry-duration, 2s)
+      cubic-bezier(0.19, 1, 0.22, 1) var(--hero-entry-delay, 0s) both;
   }
 
   .hero-dot-inner {
@@ -313,18 +315,20 @@
     }
   }
 
-  @keyframes hero-ring-entry {
+  @keyframes hero-rings-flow {
     0% {
-      transform: translateX(120%);
+      transform: translateX(55%) translateY(40px) scale(0.92);
       opacity: 0;
     }
-    60% {
-      transform: translateX(-6%);
+    40% {
       opacity: 1;
+      transform: translateX(20%) translateY(40px) scale(0.98);
+    }
+    75% {
+      transform: translateX(0%) translateY(0px) scale(1.02);
     }
     100% {
-      transform: translateX(0%);
-      opacity: 1;
+      transform: translateX(0%) translateY(0px) scale(1);
     }
   }
 
@@ -358,11 +362,18 @@
 
   @keyframes hero-dot-assemble {
     0% {
-      transform: translate(-50%, -50%) translateX(var(--dot-line-offset, 0px));
+      transform: translate(-50%, calc(-50% + var(--ring-line-y-offset, 60px)))
+        translateX(
+          calc(var(--dot-line-offset, 0px) + var(--ring-line-entry-offset, 0vw))
+        );
       opacity: 0;
     }
-    40% {
+    35% {
       opacity: 1;
+    }
+    60% {
+      transform: translate(-50%, calc(-50% + var(--ring-line-y-offset, 60px)))
+        translateX(var(--dot-line-offset, 0px));
     }
     100% {
       transform: translate(-50%, -50%) rotate(var(--dot-angle))

--- a/bafa-buddy-main/src/pages/Index.tsx
+++ b/bafa-buddy-main/src/pages/Index.tsx
@@ -32,14 +32,13 @@ import { useLanguage } from "@/contexts/LanguageContext";
 
 const Index = () => {
   const { t } = useLanguage();
-  const heroEntryDuration = 1.6;
+  const heroEntryDuration = 2;
   const heroRings = [
     {
       size: 384,
       top: "2.5rem",
       left: "5%",
       dots: 18,
-      delay: 0,
       dotSize: 12,
       color: "rgba(79, 70, 229, 0.45)",
       glow: "rgba(79, 70, 229, 0.35)"
@@ -49,7 +48,6 @@ const Index = () => {
       top: "5rem",
       left: "30%",
       dots: 20,
-      delay: 0.6,
       dotSize: 14,
       color: "rgba(59, 130, 246, 0.45)",
       glow: "rgba(59, 130, 246, 0.35)"
@@ -59,7 +57,6 @@ const Index = () => {
       top: "1.5rem",
       left: "58%",
       dots: 24,
-      delay: 1.2,
       dotSize: 14,
       color: "rgba(20, 184, 166, 0.45)",
       glow: "rgba(20, 184, 166, 0.35)"
@@ -69,7 +66,6 @@ const Index = () => {
       top: "6rem",
       left: "78%",
       dots: 16,
-      delay: 1.8,
       dotSize: 10,
       color: "rgba(14, 165, 233, 0.45)",
       glow: "rgba(14, 165, 233, 0.35)"
@@ -85,7 +81,7 @@ const Index = () => {
 
         {/* Animated circles covering two-thirds of banner on desktop */}
         <div className="pointer-events-none absolute inset-y-0 right-0 w-full lg:w-2/3">
-          <div className="relative w-full h-full">
+          <div className="relative w-full h-full hero-rings-wrapper">
             {heroRings.map((ring, ringIndex) => {
               const radius = ring.size / 2 - ring.dotSize;
               return (
@@ -97,12 +93,13 @@ const Index = () => {
                     height: ring.size,
                     top: ring.top,
                     left: ring.left,
-                    "--hero-entry-delay": `${ring.delay}s`,
                     "--hero-entry-duration": `${heroEntryDuration}s`,
                     "--ring-radius": `${radius}px`,
                     "--ring-dot-size": `${ring.dotSize}px`,
                     "--ring-dot-color-light": ring.color,
-                    "--ring-glow-color-light": ring.glow
+                    "--ring-glow-color-light": ring.glow,
+                    "--ring-line-entry-offset": "40vw",
+                    "--ring-line-y-offset": "72px"
                   } as CSSProperties}
                 >
                   {Array.from({ length: ring.dots }).map((_, dotIndex) => {
@@ -141,7 +138,7 @@ const Index = () => {
               >
                 {t('hero.badge')}
               </Badge>
-              <h1 className="text-5xl lg:text-7xl font-bold leading-[0.9] tracking-tight">
+              <h1 className="text-5xl lg:text-7xl font-bold leading-[1.05] tracking-tight">
                 <span className="animate-hero-text">{t('hero.title.the')}</span>{" "}
                 <span className="animate-hero-text-delayed animate-text-glow text-foreground">{t('hero.title.smart')}</span>{" "}
                 <span className="animate-hero-text-delayed-2">{t('hero.title.for')}</span>{" "}


### PR DESCRIPTION
## Summary
- increase hero headline line-height to prevent descender clipping
- rework hero ring animation to flow in as a cohesive arc of dots before forming circles
- add wrapper animation and updated keyframes for a smoother entry sequence

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de799869b08321ba7028f333c59d74