### PR TITLE
Fix hero banner animation alignment and heading spacing

### DIFF
--- a/bafa-buddy-main/src/index.css
+++ b/bafa-buddy-main/src/index.css
@@ -226,6 +226,7 @@
     position: absolute;
     border-radius: 9999px;
     overflow: visible;
+    transform-origin: center;
     --ring-dot-color: var(--ring-dot-color-light, rgba(79, 70, 229, 0.45));
     --ring-glow-color: var(--ring-glow-color-light, rgba(79, 70, 229, 0.35));
     --ring-dot-size: var(--ring-dot-size, 12px);
@@ -322,18 +323,18 @@
 
   @keyframes hero-rings-flow {
     0% {
-      transform: translateX(55%) translateY(40px) scale(0.92);
       opacity: 0;
+      transform: scale(0.92);
     }
     40% {
       opacity: 1;
-      transform: translateX(20%) translateY(40px) scale(0.98);
+      transform: scale(0.98);
     }
     75% {
-      transform: translateX(0%) translateY(0px) scale(1.02);
+      transform: scale(1.02);
     }
     100% {
-      transform: translateX(0%) translateY(0px) scale(1);
+      transform: scale(1);
     }
   }
 

--- a/bafa-buddy-main/src/pages/Index.tsx
+++ b/bafa-buddy-main/src/pages/Index.tsx
@@ -138,7 +138,7 @@ const Index = () => {
               >
                 {t('hero.badge')}
               </Badge>
-              <h1 className="text-5xl lg:text-7xl font-bold leading-[1.15] tracking-tight">
+              <h1 className="text-5xl lg:text-7xl font-bold leading-tight lg:leading-[1.2] tracking-tight">
                 <span className="animate-hero-text">{t('hero.title.the')}</span>{" "}
                 <span className="animate-hero-text-delayed animate-text-glow text-foreground">{t('hero.title.smart')}</span>{" "}
                 <span className="animate-hero-text-delayed-2">{t('hero.title.for')}</span>{" "}


### PR DESCRIPTION
## Summary
- keep hero ring entry animations centered by removing wrapper translation and enforcing a centered transform origin
- adjust hero heading line height so tall glyphs render without being clipped

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de7dad1a048321815240a05d1e3fe1