### PR TITLE
Refine hero ring animations and add scroll-responsive effects

### DIFF
--- a/bafa-buddy-main/src/index.css
+++ b/bafa-buddy-main/src/index.css
@@ -220,6 +220,10 @@
     height: 100%;
     animation: hero-rings-flow var(--hero-entry-duration, 2s)
       cubic-bezier(0.19, 1, 0.22, 1) both;
+    --scroll-shift-x: 0px;
+    --scroll-shift-y: 0px;
+    --scroll-tilt: 0deg;
+    --scroll-glow-multiplier: 1;
   }
 
   .hero-ring {
@@ -239,13 +243,17 @@
         cubic-bezier(0.19, 1, 0.22, 1) var(--hero-entry-delay, 0s) both,
       wave-motion 6s ease-in-out
         calc(var(--hero-entry-duration) + var(--hero-wave-delay-offset)) infinite;
+    filter: drop-shadow(
+      0 0 calc(12px * var(--scroll-glow-multiplier, 1)) var(--ring-glow-color)
+    );
   }
 
   .hero-dot {
     position: absolute;
     top: 50%;
     left: 50%;
-    transform: translate(-50%, -50%) rotate(var(--dot-angle))
+    transform: translate(-50%, -50%)
+      rotate(calc(var(--dot-angle) + var(--scroll-tilt, 0deg)))
       translateX(var(--ring-radius));
     opacity: 0;
     animation: hero-dot-assemble var(--hero-entry-duration, 2s)
@@ -258,7 +266,8 @@
     height: var(--ring-dot-size);
     border-radius: 9999px;
     background: var(--ring-dot-color);
-    box-shadow: 0 0 16px var(--ring-glow-color);
+    box-shadow: 0 0 calc(16px * var(--scroll-glow-multiplier, 1))
+      var(--ring-glow-color);
     opacity: 0.9;
     animation: dot-float var(--dot-duration, 4s) ease-in-out infinite;
     animation-delay: calc(
@@ -330,67 +339,97 @@
       opacity: 1;
       transform: scale(0.98);
     }
-    75% {
-      transform: scale(1.02);
-    }
     100% {
       transform: scale(1);
+      opacity: 1;
     }
   }
 
   @keyframes hero-ring-entry {
     0% {
-      transform: scale(0.35);
+      transform: translateX(var(--scroll-shift-x, 0px))
+        translateY(var(--scroll-shift-y, 0px)) rotate(var(--scroll-tilt, 0deg))
+        scale(0.35);
       opacity: 0;
     }
     65% {
       opacity: 1;
-      transform: scale(1.05);
+      transform: translateX(var(--scroll-shift-x, 0px))
+        translateY(var(--scroll-shift-y, 0px)) rotate(var(--scroll-tilt, 0deg))
+        scale(1);
     }
     100% {
       opacity: 1;
-      transform: scale(1);
+      transform: translateX(var(--scroll-shift-x, 0px))
+        translateY(var(--scroll-shift-y, 0px)) rotate(var(--scroll-tilt, 0deg))
+        scale(1);
     }
   }
 
   @keyframes wave-motion {
-    0%, 100% {
-      transform: translateX(0) translateY(0) scale(1);
+    0%,
+    100% {
+      transform: translateX(var(--scroll-shift-x, 0px))
+        translateY(var(--scroll-shift-y, 0px)) rotate(var(--scroll-tilt, 0deg))
+        scale(1);
     }
     25% {
-      transform: translateX(-20px) translateY(-10px) scale(1.02);
+      transform: translateX(calc(var(--scroll-shift-x, 0px) - 20px))
+        translateY(calc(var(--scroll-shift-y, 0px) - 10px))
+        rotate(var(--scroll-tilt, 0deg)) scale(1.01);
     }
     50% {
-      transform: translateX(-40px) translateY(0) scale(1);
+      transform: translateX(calc(var(--scroll-shift-x, 0px) - 40px))
+        translateY(var(--scroll-shift-y, 0px)) rotate(var(--scroll-tilt, 0deg))
+        scale(1);
     }
     75% {
-      transform: translateX(-20px) translateY(10px) scale(1.02);
+      transform: translateX(calc(var(--scroll-shift-x, 0px) - 20px))
+        translateY(calc(var(--scroll-shift-y, 0px) + 10px))
+        rotate(var(--scroll-tilt, 0deg)) scale(1.01);
     }
   }
 
   @keyframes dot-float {
     0%,
     100% {
-      transform: translate3d(0, 0, 0) scale(1);
+      transform: translate3d(
+          calc(var(--scroll-shift-x, 0px) * 0.05),
+          calc(var(--scroll-shift-y, 0px) * 0.05),
+          0
+        )
+        scale(1);
     }
     30% {
-      transform: translate3d(6px, -8px, 0) scale(1.08);
+      transform: translate3d(
+          calc(var(--scroll-shift-x, 0px) * 0.05 + 6px),
+          calc(var(--scroll-shift-y, 0px) * 0.05 - 8px),
+          0
+        )
+        scale(1.06);
     }
     60% {
-      transform: translate3d(-5px, 6px, 0) scale(0.94);
+      transform: translate3d(
+          calc(var(--scroll-shift-x, 0px) * 0.05 - 5px),
+          calc(var(--scroll-shift-y, 0px) * 0.05 + 6px),
+          0
+        )
+        scale(0.96);
     }
   }
 
   @keyframes hero-dot-assemble {
     0% {
-      transform: translate(-50%, -50%) rotate(var(--dot-angle)) translateX(0);
+      transform: translate(-50%, -50%)
+        rotate(calc(var(--dot-angle) + var(--scroll-tilt, 0deg))) translateX(0);
       opacity: 0;
     }
     45% {
       opacity: 1;
     }
     100% {
-      transform: translate(-50%, -50%) rotate(var(--dot-angle))
+      transform: translate(-50%, -50%)
+        rotate(calc(var(--dot-angle) + var(--scroll-tilt, 0deg)))
         translateX(var(--ring-radius));
       opacity: 1;
     }

--- a/bafa-buddy-main/src/pages/Index.tsx
+++ b/bafa-buddy-main/src/pages/Index.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties } from "react";
+import { useEffect, useRef, type CSSProperties } from "react";
 import Navigation from "@/components/Navigation";
 import InteractiveFeatures from "@/components/InteractiveFeatures";
 import { Button } from "@/components/ui/button";
@@ -33,6 +33,50 @@ import { useLanguage } from "@/contexts/LanguageContext";
 const Index = () => {
   const { t } = useLanguage();
   const heroEntryDuration = 2;
+  const heroSectionRef = useRef<HTMLElement | null>(null);
+  const heroWrapperRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const updateScrollEffects = () => {
+      const wrapper = heroWrapperRef.current;
+      const section = heroSectionRef.current;
+
+      if (!wrapper || !section) {
+        return;
+      }
+
+      const viewportHeight = window.innerHeight || 1;
+      const rect = section.getBoundingClientRect();
+      const visibleHeight = Math.min(
+        Math.max(viewportHeight - rect.top, 0),
+        viewportHeight + rect.height
+      );
+      const progress = Math.min(
+        Math.max(visibleHeight / (viewportHeight + rect.height), 0),
+        1
+      );
+      const shift = (progress - 0.5) * 48;
+      const tilt = (progress - 0.5) * 14;
+      const glow = 0.8 + progress * 0.2;
+
+      wrapper.style.setProperty("--scroll-shift-x", `${shift}px`);
+      wrapper.style.setProperty("--scroll-shift-y", `${shift * -0.35}px`);
+      wrapper.style.setProperty("--scroll-tilt", `${tilt}deg`);
+      wrapper.style.setProperty("--scroll-glow-multiplier", glow.toFixed(2));
+    };
+
+    updateScrollEffects();
+
+    const passiveOptions: AddEventListenerOptions = { passive: true };
+
+    window.addEventListener("scroll", updateScrollEffects, passiveOptions);
+    window.addEventListener("resize", updateScrollEffects);
+
+    return () => {
+      window.removeEventListener("scroll", updateScrollEffects);
+      window.removeEventListener("resize", updateScrollEffects);
+    };
+  }, []);
   const heroRings = [
     {
       size: 384,
@@ -76,12 +120,18 @@ const Index = () => {
       <Navigation />
 
       {/* Hero Section */}
-      <section className="relative mt-16 h-[calc(100vh-4rem)] flex items-center overflow-hidden">
+      <section
+        ref={heroSectionRef}
+        className="relative mt-16 h-[calc(100vh-4rem)] flex items-center overflow-hidden"
+      >
         <div className="absolute inset-0 grid-pattern-subtle opacity-40"></div>
 
         {/* Animated circles covering two-thirds of banner on desktop */}
         <div className="pointer-events-none absolute inset-y-0 right-0 w-full lg:w-2/3">
-          <div className="relative w-full h-full hero-rings-wrapper">
+          <div
+            ref={heroWrapperRef}
+            className="relative w-full h-full hero-rings-wrapper"
+          >
             {heroRings.map((ring, ringIndex) => {
               const radius = ring.size / 2 - ring.dotSize;
               return (


### PR DESCRIPTION
## Summary
- smooth out the hero ring entry animation so the dots settle without an overshoot
- add scroll-driven CSS variables and listeners to give the rings and dots a subtle interactive response

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de801342d883219c3f5b977096a46a