### PR TITLE
Improve hero ring motion timing

### DIFF
--- a/bafa-buddy-main/src/index.css
+++ b/bafa-buddy-main/src/index.css
@@ -218,11 +218,13 @@
     position: relative;
     width: 100%;
     height: 100%;
-    animation: hero-rings-flow var(--hero-entry-duration, 2s)
+    animation: hero-rings-flow var(--hero-entry-duration, 1.2s)
       cubic-bezier(0.19, 1, 0.22, 1) both;
-    --scroll-shift-x: 0px;
-    --scroll-shift-y: 0px;
+    --scroll-progress: 0;
+    --scroll-drift-x: 0px;
+    --scroll-drift-y: 0px;
     --scroll-tilt: 0deg;
+    --scroll-spin: 0deg;
     --scroll-glow-multiplier: 1;
   }
 
@@ -235,14 +237,27 @@
     --ring-glow-color: var(--ring-glow-color-light, rgba(79, 70, 229, 0.35));
     --ring-dot-size: var(--ring-dot-size, 12px);
     --ring-radius: var(--ring-radius, 150px);
-    --hero-entry-duration: 2s;
+    --hero-entry-duration: 1.2s;
+    --hero-entry-delay: 0s;
     --hero-wave-delay-offset: 0s;
+    --ring-wave-duration: 7s;
+    --ring-wave-delay: var(--hero-wave-delay-offset, 0s);
+    --ring-wave-distance: 24px;
+    --ring-wave-tilt: 3deg;
+    --ring-rotation-direction: 1;
+    --ring-pulse-scale: 0.04;
+    --ring-float-offset: 8px;
+    --ring-float-depth: 6px;
     opacity: 0;
     animation:
-      hero-ring-entry var(--hero-entry-duration, 2s)
+      hero-ring-entry var(--hero-entry-duration, 1.2s)
         cubic-bezier(0.19, 1, 0.22, 1) var(--hero-entry-delay, 0s) both,
-      wave-motion 6s ease-in-out
-        calc(var(--hero-entry-duration) + var(--hero-wave-delay-offset)) infinite;
+      hero-ring-orbit var(--ring-wave-duration, 7s) ease-in-out
+        calc(
+          var(--hero-entry-duration, 1.2s) +
+            var(--ring-wave-delay, var(--hero-wave-delay-offset, 0s))
+        )
+        infinite alternate;
     filter: drop-shadow(
       0 0 calc(12px * var(--scroll-glow-multiplier, 1)) var(--ring-glow-color)
     );
@@ -272,7 +287,7 @@
     animation: dot-float var(--dot-duration, 4s) ease-in-out infinite;
     animation-delay: calc(
       var(--dot-delay, 0s) + var(--hero-entry-delay, 0s) +
-        var(--hero-entry-duration, 2s)
+        var(--hero-entry-duration, 1.2s)
     );
   }
 
@@ -333,60 +348,108 @@
   @keyframes hero-rings-flow {
     0% {
       opacity: 0;
-      transform: scale(0.92);
+      transform: translate3d(
+          calc(var(--scroll-drift-x, 0px) * 0.1),
+          calc(var(--scroll-drift-y, 0px) * 0.1),
+          0
+        )
+        rotate(calc(var(--scroll-spin, 0deg) * 0.3)) scale(0.9);
     }
-    40% {
+    45% {
       opacity: 1;
-      transform: scale(0.98);
+      transform: translate3d(
+          calc(var(--scroll-drift-x, 0px) * 0.12),
+          calc(var(--scroll-drift-y, 0px) * 0.12),
+          0
+        )
+        rotate(calc(var(--scroll-spin, 0deg) * 0.32)) scale(0.97);
     }
     100% {
-      transform: scale(1);
+      transform: translate3d(
+          calc(var(--scroll-drift-x, 0px) * 0.14),
+          calc(var(--scroll-drift-y, 0px) * 0.14),
+          0
+        )
+        rotate(calc(var(--scroll-spin, 0deg) * 0.35)) scale(1);
       opacity: 1;
     }
   }
 
   @keyframes hero-ring-entry {
     0% {
-      transform: translateX(var(--scroll-shift-x, 0px))
-        translateY(var(--scroll-shift-y, 0px)) rotate(var(--scroll-tilt, 0deg))
+      transform: translateX(var(--scroll-drift-x, 0px))
+        translateY(var(--scroll-drift-y, 0px))
+        rotate(calc(var(--scroll-tilt, 0deg) + var(--scroll-spin, 0deg)))
         scale(0.35);
       opacity: 0;
     }
     65% {
       opacity: 1;
-      transform: translateX(var(--scroll-shift-x, 0px))
-        translateY(var(--scroll-shift-y, 0px)) rotate(var(--scroll-tilt, 0deg))
+      transform: translateX(var(--scroll-drift-x, 0px))
+        translateY(var(--scroll-drift-y, 0px))
+        rotate(calc(var(--scroll-tilt, 0deg) + var(--scroll-spin, 0deg)))
         scale(1);
     }
     100% {
       opacity: 1;
-      transform: translateX(var(--scroll-shift-x, 0px))
-        translateY(var(--scroll-shift-y, 0px)) rotate(var(--scroll-tilt, 0deg))
+      transform: translateX(var(--scroll-drift-x, 0px))
+        translateY(var(--scroll-drift-y, 0px))
+        rotate(calc(var(--scroll-tilt, 0deg) + var(--scroll-spin, 0deg)))
         scale(1);
     }
   }
 
-  @keyframes wave-motion {
+  @keyframes hero-ring-orbit {
     0%,
     100% {
-      transform: translateX(var(--scroll-shift-x, 0px))
-        translateY(var(--scroll-shift-y, 0px)) rotate(var(--scroll-tilt, 0deg))
+      transform: translateX(var(--scroll-drift-x, 0px))
+        translateY(var(--scroll-drift-y, 0px))
+        rotate(calc(var(--scroll-tilt, 0deg) + var(--scroll-spin, 0deg)))
         scale(1);
     }
-    25% {
-      transform: translateX(calc(var(--scroll-shift-x, 0px) - 20px))
-        translateY(calc(var(--scroll-shift-y, 0px) - 10px))
-        rotate(var(--scroll-tilt, 0deg)) scale(1.01);
+    38% {
+      transform: translateX(
+          calc(
+            var(--scroll-drift-x, 0px) +
+              var(--ring-wave-distance, 24px) * var(--ring-rotation-direction, 1)
+          )
+        )
+        translateY(
+          calc(
+            var(--scroll-drift-y, 0px) - var(--ring-wave-distance, 24px) * 0.45
+          )
+        )
+        rotate(
+          calc(
+            var(--scroll-tilt, 0deg) + var(--scroll-spin, 0deg) +
+              var(--ring-wave-tilt, 3deg) * var(--ring-rotation-direction, 1)
+          )
+        )
+        scale(calc(1 + var(--ring-pulse-scale, 0.04)));
     }
-    50% {
-      transform: translateX(calc(var(--scroll-shift-x, 0px) - 40px))
-        translateY(var(--scroll-shift-y, 0px)) rotate(var(--scroll-tilt, 0deg))
-        scale(1);
-    }
-    75% {
-      transform: translateX(calc(var(--scroll-shift-x, 0px) - 20px))
-        translateY(calc(var(--scroll-shift-y, 0px) + 10px))
-        rotate(var(--scroll-tilt, 0deg)) scale(1.01);
+    72% {
+      transform: translateX(
+          calc(
+            var(--scroll-drift-x, 0px) -
+              var(--ring-wave-distance, 24px) * 0.6 *
+              var(--ring-rotation-direction, 1)
+          )
+        )
+        translateY(
+          calc(
+            var(--scroll-drift-y, 0px) + var(--ring-wave-distance, 24px) * 0.55
+          )
+        )
+        rotate(
+          calc(
+            var(--scroll-tilt, 0deg) + var(--scroll-spin, 0deg) -
+              var(--ring-wave-tilt, 3deg) * 0.65 *
+              var(--ring-rotation-direction, 1)
+          )
+        )
+        scale(
+          calc(1 - var(--ring-pulse-scale, 0.04) * 0.55)
+        );
     }
   }
 
@@ -394,27 +457,36 @@
     0%,
     100% {
       transform: translate3d(
-          calc(var(--scroll-shift-x, 0px) * 0.05),
-          calc(var(--scroll-shift-y, 0px) * 0.05),
+          calc(var(--scroll-drift-x, 0px) * 0.05),
+          calc(var(--scroll-drift-y, 0px) * 0.05),
           0
         )
         scale(1);
     }
-    30% {
+    35% {
       transform: translate3d(
-          calc(var(--scroll-shift-x, 0px) * 0.05 + 6px),
-          calc(var(--scroll-shift-y, 0px) * 0.05 - 8px),
+          calc(
+            var(--scroll-drift-x, 0px) * 0.05 + var(--ring-float-offset, 8px)
+          ),
+          calc(
+            var(--scroll-drift-y, 0px) * 0.05 - var(--ring-float-depth, 6px)
+          ),
           0
         )
-        scale(1.06);
+        scale(calc(1 + var(--ring-pulse-scale, 0.04) * 0.85));
     }
-    60% {
+    70% {
       transform: translate3d(
-          calc(var(--scroll-shift-x, 0px) * 0.05 - 5px),
-          calc(var(--scroll-shift-y, 0px) * 0.05 + 6px),
+          calc(
+            var(--scroll-drift-x, 0px) * 0.05 -
+              var(--ring-float-offset, 8px) * 0.65
+          ),
+          calc(
+            var(--scroll-drift-y, 0px) * 0.05 + var(--ring-float-depth, 6px)
+          ),
           0
         )
-        scale(0.96);
+        scale(calc(1 - var(--ring-pulse-scale, 0.04) * 0.5));
     }
   }
 

--- a/bafa-buddy-main/src/pages/Index.tsx
+++ b/bafa-buddy-main/src/pages/Index.tsx
@@ -32,7 +32,7 @@ import { useLanguage } from "@/contexts/LanguageContext";
 
 const Index = () => {
   const { t } = useLanguage();
-  const heroEntryDuration = 2;
+  const heroEntryDuration = 1.2;
   const heroSectionRef = useRef<HTMLElement | null>(null);
   const heroWrapperRef = useRef<HTMLDivElement | null>(null);
 
@@ -55,13 +55,18 @@ const Index = () => {
         Math.max(visibleHeight / (viewportHeight + rect.height), 0),
         1
       );
-      const shift = (progress - 0.5) * 48;
-      const tilt = (progress - 0.5) * 14;
-      const glow = 0.8 + progress * 0.2;
+      const easedProgress = Math.sin(progress * Math.PI * 0.5);
+      const driftX = Math.sin(progress * Math.PI) * 36;
+      const driftY = Math.cos(progress * Math.PI * 0.85) * 22 - 10;
+      const tilt = (progress - 0.5) * 18;
+      const spin = Math.sin(progress * Math.PI * 1.15) * 9;
+      const glow = 0.88 + easedProgress * 0.32;
 
-      wrapper.style.setProperty("--scroll-shift-x", `${shift}px`);
-      wrapper.style.setProperty("--scroll-shift-y", `${shift * -0.35}px`);
-      wrapper.style.setProperty("--scroll-tilt", `${tilt}deg`);
+      wrapper.style.setProperty("--scroll-progress", progress.toFixed(3));
+      wrapper.style.setProperty("--scroll-drift-x", `${driftX.toFixed(2)}px`);
+      wrapper.style.setProperty("--scroll-drift-y", `${driftY.toFixed(2)}px`);
+      wrapper.style.setProperty("--scroll-tilt", `${tilt.toFixed(2)}deg`);
+      wrapper.style.setProperty("--scroll-spin", `${spin.toFixed(2)}deg`);
       wrapper.style.setProperty("--scroll-glow-multiplier", glow.toFixed(2));
     };
 
@@ -85,7 +90,17 @@ const Index = () => {
       dots: 18,
       dotSize: 12,
       color: "rgba(79, 70, 229, 0.45)",
-      glow: "rgba(79, 70, 229, 0.35)"
+      glow: "rgba(79, 70, 229, 0.35)",
+      entryDelay: 0,
+      waveDuration: 7.4,
+      waveDelay: 0.18,
+      waveDistance: 22,
+      waveTilt: 2.4,
+      direction: 1,
+      pulseScale: 0.032,
+      floatOffset: 9,
+      floatDepth: 7,
+      floatSpeed: 1
     },
     {
       size: 448,
@@ -94,7 +109,17 @@ const Index = () => {
       dots: 20,
       dotSize: 14,
       color: "rgba(59, 130, 246, 0.45)",
-      glow: "rgba(59, 130, 246, 0.35)"
+      glow: "rgba(59, 130, 246, 0.35)",
+      entryDelay: 0.08,
+      waveDuration: 6.6,
+      waveDelay: 0.42,
+      waveDistance: 28,
+      waveTilt: 3.6,
+      direction: -1,
+      pulseScale: 0.045,
+      floatOffset: 11,
+      floatDepth: 8,
+      floatSpeed: 0.92
     },
     {
       size: 512,
@@ -103,7 +128,17 @@ const Index = () => {
       dots: 24,
       dotSize: 14,
       color: "rgba(20, 184, 166, 0.45)",
-      glow: "rgba(20, 184, 166, 0.35)"
+      glow: "rgba(20, 184, 166, 0.35)",
+      entryDelay: 0.16,
+      waveDuration: 8.2,
+      waveDelay: 0.28,
+      waveDistance: 32,
+      waveTilt: 4.2,
+      direction: 1,
+      pulseScale: 0.052,
+      floatOffset: 13,
+      floatDepth: 10,
+      floatSpeed: 1.08
     },
     {
       size: 320,
@@ -112,7 +147,17 @@ const Index = () => {
       dots: 16,
       dotSize: 10,
       color: "rgba(14, 165, 233, 0.45)",
-      glow: "rgba(14, 165, 233, 0.35)"
+      glow: "rgba(14, 165, 233, 0.35)",
+      entryDelay: 0.24,
+      waveDuration: 5.9,
+      waveDelay: 0.6,
+      waveDistance: 18,
+      waveTilt: 2.2,
+      direction: -1,
+      pulseScale: 0.036,
+      floatOffset: 8,
+      floatDepth: 6,
+      floatSpeed: 0.88
     }
   ];
   return (
@@ -144,18 +189,32 @@ const Index = () => {
                     top: ring.top,
                     left: ring.left,
                     "--hero-entry-duration": `${heroEntryDuration}s`,
+                    "--hero-entry-delay": `${ring.entryDelay ?? 0}s`,
                     "--ring-radius": `${radius}px`,
                     "--ring-dot-size": `${ring.dotSize}px`,
                     "--ring-dot-color-light": ring.color,
                     "--ring-glow-color-light": ring.glow,
                     "--ring-line-entry-offset": "40vw",
-                    "--ring-line-y-offset": "72px"
+                    "--ring-line-y-offset": "72px",
+                    "--ring-wave-duration": `${ring.waveDuration}s`,
+                    "--ring-wave-delay": `${ring.waveDelay}s`,
+                    "--ring-wave-distance": `${ring.waveDistance}px`,
+                    "--ring-wave-tilt": `${ring.waveTilt}deg`,
+                    "--ring-rotation-direction": ring.direction,
+                    "--ring-pulse-scale": ring.pulseScale,
+                    "--ring-float-offset": `${ring.floatOffset}px`,
+                    "--ring-float-depth": `${ring.floatDepth}px`
                   } as CSSProperties}
                 >
                   {Array.from({ length: ring.dots }).map((_, dotIndex) => {
                     const angle = (dotIndex / ring.dots) * 360;
-                    const floatDuration = 4 + ((dotIndex + ringIndex) % 5) * 0.6;
-                    const floatDelay = (dotIndex % ring.dots) * 0.12;
+                    const floatDuration =
+                      (3.4 + ((dotIndex + ringIndex) % 5) * 0.5) *
+                      ring.floatSpeed;
+                    const floatDelay =
+                      (ring.entryDelay ?? 0) +
+                      (((dotIndex + ringIndex * 3) % ring.dots) * 0.08 +
+                        ring.waveDelay * 0.5);
                     const lineOffset =
                       (dotIndex - (ring.dots - 1) / 2) * ring.dotSize * 1.6;
                     return (


### PR DESCRIPTION
## Summary
- shorten the hero ring entry timing and add per-ring motion parameters so each orbit animates independently
- redesign the scroll-driven drift and glow logic with new CSS animations for smoother continuous movement

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de8241b5008321bd0587e1e0184809